### PR TITLE
feat: SWEEP_PRE_CMD / SWEEP_POST_CMD server lifecycle hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-**llamaseye** is a single-file Bash script (`llamaseye.sh`) that exhaustively benchmarks every meaningful llama-bench parameter combination for GGUF models. There is no build step — the entry point is the script itself.
+**smartsweep** combines two things:
+
+1. **llamaseye** (`llamaseye.sh`) — a single-file Bash sweep engine that exhaustively benchmarks every meaningful llama-bench parameter combination for GGUF models. No build step.
+2. **Agent loop** — an AI agent reads `strategy.md` (the research objective), runs llamaseye phases, and iterates to find the fastest inference config. Results are logged to `results.tsv`.
+
+The agent loop is described in `strategy.md`. The sweep engine is `llamaseye.sh`.
 
 ## Running the script
 
@@ -29,6 +34,12 @@ bash llamaseye.sh --model ~/Models/model.gguf --only-phases 6,7
 
 # Dry run (print commands without executing)
 bash llamaseye.sh --model ~/Models/model.gguf --dry-run
+
+# Goal-directed Phase 7 — stop early once a config meets the spec
+bash llamaseye.sh --model ~/Models/model.gguf --only-phases 7 --goal "ctx=32768,tg=5"
+
+# Fine context ceiling — midpoint bisection inside Phase 6 for precise ceiling
+bash llamaseye.sh --model ~/Models/model.gguf --fine-ctx
 ```
 
 **Environment / .env file:**
@@ -38,6 +49,34 @@ cp example.env .env
 source .env && bash llamaseye.sh --models-dir ~/Models
 ```
 `.env` is gitignored. `example.env` documents every available variable with defaults.
+
+**Server lifecycle hooks (optional — only if something else shares the GPU):**
+
+On cloud instances, dedicated bench machines, or any setup where nothing else uses the GPU,
+you can skip this entirely — just run llamaseye.sh directly.
+
+If the machine runs Ollama, LM Studio, llama-power, or any other process that holds VRAM,
+you should stop it before sweeping. llamaseye has built-in hooks for this:
+
+```bash
+# Stop your server before the sweep, restart it after (even on crash/Ctrl-C)
+export SWEEP_PRE_CMD="llama-power-stop"   # or: systemctl stop ollama / lms server stop
+export SWEEP_POST_CMD="llama-power-start" # or: systemctl start ollama / lms server start
+bash llamaseye.sh --model ~/Models/model.gguf
+```
+
+Or via `.env`:
+```bash
+SWEEP_PRE_CMD="llama-power-stop"
+SWEEP_POST_CMD="llama-power-start"
+```
+
+Leave both unset (the default) to skip the hooks entirely.
+
+**Why it matters when set:** Phase 0 binary-searches for `MAX_NGL` — the maximum GPU layers
+that fit in VRAM. If another process is holding VRAM when Phase 0 runs, `MAX_NGL` will be
+wrong and will poison every downstream phase. `SWEEP_POST_CMD` is registered as a bash
+`EXIT` trap so it fires on clean exit, crash, and Ctrl-C — the server always comes back.
 
 ## Architecture
 
@@ -108,6 +147,30 @@ OPT_RESUME="${SWEEP_RESUME:-false}"   # env var sets default; CLI overrides
 - Pure-bash array builders are used in `save_state()` instead of jq pipelines (a previous bug source — jq arrays from bash loops had quoting issues)
 - Phase functions append to working sets with `WS_NGL+=" $val"` (space-separated strings, not arrays) to survive subshell boundaries
 - OOM detection uses `detect_oom()` called on the raw output file, not stderr trapping, because `timeout` complicates signal propagation
+
+## Agent loop workflow
+
+The agent loop (described in `strategy.md`) follows this pattern:
+
+1. Create a branch `smartsweep/<tag>` (e.g. `smartsweep/apr5`)
+2. Run phases 0–6 as baseline to establish working sets and context ceiling
+3. Loop: read `sweep.jsonl`, propose a Phase 7 variation, run it with `--only-phases 7 [--goal ...]`, record the best result in `results.tsv`, commit if improved
+4. `results.tsv` is the experiment log — columns: `commit tok_s ctx ngl fa ctk batch ubatch threads nkvo status description`
+
+The agent must never modify `llamaseye.sh` core logic, output formats, or hardware detection. Only `SWEEP_*` env vars, phase selection, and `--goal` flags are in scope.
+
+**Querying sweep.jsonl** (source of truth, not sweep.md):
+```bash
+# Best tok/s from Phase 7
+jq -r 'select(.phase==7) | [.tok_s, .ngl, .ctx, .fa, .ctk, .batch, .ubatch, .threads, .nkvo] | @tsv' \
+  results/*/sweep.jsonl | sort -rn | head -5
+```
+
+## Linting
+
+```bash
+shellcheck llamaseye.sh
+```
 
 ## Documentation update rule
 

--- a/example.env
+++ b/example.env
@@ -95,6 +95,46 @@ SWEEP_COOL_POLL_SEC=20
 # Skip the pre-sweep confirmation prompt. Equivalent to --no-confirm.
 # SWEEP_NO_CONFIRM=false
 
+# -----------------------------------------------------------------------------
+# Server lifecycle hooks
+# -----------------------------------------------------------------------------
+#
+# llamaseye needs exclusive GPU access for valid results — any LLM server
+# sharing VRAM will corrupt Phase 0's MAX_NGL discovery and all downstream
+# phases.  These two hooks let you stop your server before the sweep starts
+# and restart it automatically when the sweep ends (including on crash/Ctrl-C).
+#
+# SWEEP_PRE_CMD  — runs after the confirmation prompt, before Phase 0.
+#                  If this command fails, the sweep aborts immediately.
+# SWEEP_POST_CMD — runs on EXIT (clean finish, crash, or Ctrl-C).
+#                  Always fires; failures here do not affect the sweep's exit code.
+#
+# Common examples:
+#
+#   # llama-power (custom llama.cpp proxy)
+#   SWEEP_PRE_CMD="llama-power-stop"
+#   SWEEP_POST_CMD="llama-power-start"
+#
+#   # Ollama
+#   SWEEP_PRE_CMD="systemctl stop ollama"
+#   SWEEP_POST_CMD="systemctl start ollama"
+#
+#   # Ollama (user service / no systemd)
+#   SWEEP_PRE_CMD="ollama stop"
+#   SWEEP_POST_CMD="ollama serve &"
+#
+#   # LM Studio (CLI)
+#   SWEEP_PRE_CMD="lms server stop"
+#   SWEEP_POST_CMD="lms server start"
+#
+#   # Multiple servers (chain with &&)
+#   SWEEP_PRE_CMD="llama-power-stop && systemctl stop ollama"
+#   SWEEP_POST_CMD="llama-power-start && systemctl start ollama"
+#
+# Leave unset (default) to skip both hooks — safe if nothing else uses the GPU.
+# SWEEP_PRE_CMD=""
+# SWEEP_POST_CMD=""
+
 # Disable thermal polling entirely. Equivalent to --no-thermal-guard.
 # SWEEP_NO_THERMAL=false
 

--- a/llamaseye.sh
+++ b/llamaseye.sh
@@ -73,6 +73,16 @@ SWEEP_PRIO="${SWEEP_PRIO:-2}"
 # Requires python3. Conflicts with explicit --start-* / --min-* flags.
 OPT_OPTIMIZED_SWEEP="${SWEEP_OPTIMIZED_SWEEP:-false}"
 
+# Shell command to run before the first model sweep begins (e.g. stop a server
+# to free VRAM). Runs after hardware detection and the confirmation prompt, but
+# before any llama-bench invocation.  Leave empty to skip.
+SWEEP_PRE_CMD="${SWEEP_PRE_CMD:-}"
+
+# Shell command to run after all sweeps finish (or on any exit — including
+# errors and SIGINT).  Intended to restart whatever SWEEP_PRE_CMD stopped.
+# Executed via a bash EXIT trap so it fires even on crash or Ctrl-C.
+SWEEP_POST_CMD="${SWEEP_POST_CMD:-}"
+
 # =============================================================================
 # RUNTIME STATE — populated during execution, not user-configurable
 # =============================================================================
@@ -2964,6 +2974,17 @@ main() {
         printf "Ready to sweep %d model(s). Output -> %s\n" "${#MODEL_LIST[@]}" "${SWEEP_OUTPUT_DIR}"
         read -r -p "Continue? [y/N] " reply
         [[ "${reply}" =~ ^[Yy]$ ]] || die "Aborted by user"
+    fi
+
+    # Register POST hook first so it fires on any exit from this point on
+    if [[ -n "${SWEEP_POST_CMD}" ]]; then
+        trap 'log "[hook] Running SWEEP_POST_CMD: ${SWEEP_POST_CMD}"; eval "${SWEEP_POST_CMD}" || true' EXIT
+    fi
+
+    # Run PRE hook — intended to free VRAM before Phase 0 touches the GPU
+    if [[ -n "${SWEEP_PRE_CMD}" ]]; then
+        log "[hook] Running SWEEP_PRE_CMD: ${SWEEP_PRE_CMD}"
+        eval "${SWEEP_PRE_CMD}" || die "SWEEP_PRE_CMD failed — aborting sweep"
     fi
 
     local model

--- a/skills/llamaseye/SKILL.md
+++ b/skills/llamaseye/SKILL.md
@@ -66,6 +66,18 @@ bash ~/llamaseye.sh --model ~/Models/model.gguf --only-phases 6,7
 # Unattended overnight
 nohup bash ~/llamaseye.sh --models-dir ~/Models > /dev/null 2>&1 &
 tail -f ~/Models/bench/sweep/sweep.log
+
+# ── Server lifecycle hooks (OPTIONAL) ────────────────────────────────────────
+# Only needed if another process (Ollama, llama-power, LM Studio, etc.) is
+# holding VRAM on the same machine. Cloud agents, dedicated bench machines,
+# or any setup where nothing else uses the GPU can skip this entirely.
+#
+# If set, SWEEP_PRE_CMD runs before Phase 0 and SWEEP_POST_CMD runs on exit
+# (clean finish, crash, or Ctrl-C). Leave both unset to do nothing.
+#
+# export SWEEP_PRE_CMD="llama-power-stop"    # or: systemctl stop ollama
+# export SWEEP_POST_CMD="llama-power-start"  # or: systemctl start ollama
+# bash ~/llamaseye.sh --model ~/Models/model.gguf
 ```
 
 ---
@@ -185,6 +197,8 @@ source .env && bash llamaseye.sh --models-dir ~/Models --output-dir ~/Models/ben
 
 | Variable | What it controls | Example |
 |----------|-----------------|----------|
+| `SWEEP_PRE_CMD` | *(Optional)* Shell command to run before Phase 0. Only needed if another process holds VRAM on the same machine (Ollama, llama-power, LM Studio, etc.). Sweep aborts if this fails. Leave unset on cloud/dedicated bench machines. | `llama-power-stop` |
+| `SWEEP_POST_CMD` | *(Optional)* Shell command to run on EXIT (clean finish, crash, or Ctrl-C). Pair with `SWEEP_PRE_CMD` to restart whatever it stopped. Always fires; leave unset if `SWEEP_PRE_CMD` is unset. | `llama-power-start` |
 | `LLAMA_BENCH_BIN` | Path to the standard llama-bench binary | `~/llama.cpp/build/bin/llama-bench` |
 | `SWEEP_TURBO_BENCH_BIN` | Path to TurboQuant binary (optional) | `~/llama-cpp-turboquant/build/bin/llama-bench` |
 | `SWEEP_MODELS_DIR` | Directory scanned for .gguf files | `~/Models` |


### PR DESCRIPTION
## Summary

- Adds `SWEEP_PRE_CMD` / `SWEEP_POST_CMD` env vars to stop/restart GPU-sharing processes around a sweep (Ollama, LM Studio, llama-power, etc.)
- Updates docs across `CLAUDE.md`, `example.env`, and `skills/llamaseye/SKILL.md`
- Also catches up `CLAUDE.md` with recently landed features (`--goal`, `--fine-ctx`, agent loop workflow, linting section)

## How it works

`SWEEP_PRE_CMD` runs after hardware detection and the confirmation prompt, before Phase 0. The sweep aborts if it fails.

`SWEEP_POST_CMD` is registered as a bash `EXIT` trap immediately before PRE runs — so it fires on clean exit, crash, and Ctrl-C. The server always comes back.

## Test plan

- [ ] Set `SWEEP_PRE_CMD` to a command that succeeds — verify it runs before Phase 0
- [ ] Set `SWEEP_PRE_CMD` to a failing command — verify sweep aborts and POST still fires
- [ ] Ctrl-C mid-sweep — verify `SWEEP_POST_CMD` fires
- [ ] Leave both unset — verify no change in behavior

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)